### PR TITLE
Fix compile error with Python 3.7.4

### DIFF
--- a/loader.cpp
+++ b/loader.cpp
@@ -241,7 +241,7 @@ SCSAPI_VOID telemetry_event_cb(const scs_event_t event,
 namespace pymod {
 
 static PyObject *log(PyObject *self, PyObject *arg) {
-    char *message = PyUnicode_AsUTF8AndSize(arg, nullptr);
+    const char *message = PyUnicode_AsUTF8AndSize(arg, nullptr);
     if (message == nullptr) {
         PyErr_SetString(PyExc_TypeError, "Log message must be string");
         return nullptr;


### PR DESCRIPTION
Fixes compilation error against Python 3.7.4:

```console
# make
g++ -Ieurotrucks2_telemetry_sdk_1.10/include -I/usr/include/python3.7m  -std=c++17 -fPIC -Wall -O2 -o pyets2_telemetry_loader.so --shared -Wl,--no-allow-shlib-undefined -Wl,-soname,pyets2_telemetry_loader.so  loader.cpp pyhelp.cpp log.cpp -lpython3.7m 
loader.cpp: In function ‘PyObject* pymod::log(PyObject*, PyObject*)’:
loader.cpp:244:44: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
  244 |     char *message = PyUnicode_AsUTF8AndSize(arg, nullptr);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
      |                                            |
      |                                            const char*
make: *** [Makefile:47: pyets2_telemetry_loader.so] Error 1
```

refs #1 